### PR TITLE
Fix issue with random CI failure

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -19,6 +19,7 @@ const (
 	FILE2 = "stream/vdfile_delays"
 	ADDR3 = "localhost:5555"
 	FILE3 = "stream/vdfile_mismatch"
+	ADDR4 = "localhost:6666"
 )
 
 func setupTestCase(t *testing.T, addr, file string) func() {
@@ -101,9 +102,9 @@ func TestRunWrongQueries(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
-	defer setupTestCase(t, ADDR1, FILE1)()
+	defer setupTestCase(t, ADDR4, FILE1)()
 	// connect to server
-	conn, err := net.Dial("tcp", ADDR1)
+	conn, err := net.Dial("tcp", ADDR4)
 
 	if err != nil {
 		t.Fatalf("could not connect to to server: %v\n", err)


### PR DESCRIPTION
Once in a while, the CI pipelines randomly fails. This is because one two test cases in the same time was trying to set up TCP server using same port. 
The name of the branch can be misleading but, at a first glance I thought that the reason for this was totally different. 