### PR TITLE
Add missing gG formatters

### DIFF
--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -331,7 +331,7 @@ func lexPlaceholder(l *Lexer) StateFn {
 			l.emit(ItemStringValuePlaceholder)
 			return lexStart
 		}
-		in := ".0123456789eEfFdcbtxX"
+		in := ".0123456789gGeEfFdcbtxX"
 		if l.acceptRun(in) {
 			l.emit(ItemNumberValuePlaceholder)
 			return lexStart


### PR DESCRIPTION
This PR adds two formatters `g` and `G` to lexer -> they are responsible for printing either fixed point or exponential depending on the magnitude of the value.